### PR TITLE
Improving ForkJoin usage for better performance

### DIFF
--- a/application/src/main/java/com/ejisto/modules/controller/wizard/installer/workers/LoadClassAction.java
+++ b/application/src/main/java/com/ejisto/modules/controller/wizard/installer/workers/LoadClassAction.java
@@ -57,8 +57,8 @@ class LoadClassAction extends RecursiveTask<List<MockedField>> {
     private final ProgressListener listener;
     private final MockedFieldsRepository mockedFieldsRepository;
 
-    private int from;
-    private int to;
+    private final int from;
+    private final int to;
 
     public LoadClassAction(List<String> classes, ClassLoader classLoader, WebApplicationDescriptor webApplicationDescriptor, ProgressListener listener, MockedFieldsRepository mockedFieldsRepository) {
         this.classes = classes;
@@ -68,14 +68,15 @@ class LoadClassAction extends RecursiveTask<List<MockedField>> {
         this.mockedFieldsRepository = mockedFieldsRepository;
     }
     
-    public LoadClassAction(List<String> classes, ClassLoader classLoader, WebApplicationDescriptor webApplicationDescriptor, ProgressListener listener, MockedFieldsRepository mockedFieldsRepository, int from, int to) {
+    private LoadClassAction(List<String> classes, ClassLoader classLoader, WebApplicationDescriptor webApplicationDescriptor, ProgressListener listener, MockedFieldsRepository mockedFieldsRepository, int from, int to) {
         this(classes, classLoader, webApplicationDescriptor, listener, mockedFieldsRepository);
         this.from = from;
         this.to = to;
     }
+    
     @Override
     protected List<MockedField> compute() {
-        if (to-from==0) {
+        if (to-from <= 0) {
             return emptyList();
         }
         if (to-from > THRESHOLD) {

--- a/application/src/main/java/com/ejisto/modules/controller/wizard/installer/workers/LoadClassAction.java
+++ b/application/src/main/java/com/ejisto/modules/controller/wizard/installer/workers/LoadClassAction.java
@@ -61,15 +61,15 @@ class LoadClassAction extends RecursiveTask<List<MockedField>> {
     private final int to;
 
     public LoadClassAction(List<String> classes, ClassLoader classLoader, WebApplicationDescriptor webApplicationDescriptor, ProgressListener listener, MockedFieldsRepository mockedFieldsRepository) {
+        this(classes, classLoader, webApplicationDescriptor, listener, mockedFieldsRepository, 0, classes.size());
+    }
+    
+    private LoadClassAction(List<String> classes, ClassLoader classLoader, WebApplicationDescriptor webApplicationDescriptor, ProgressListener listener, MockedFieldsRepository mockedFieldsRepository, int from, int to) {
         this.classes = classes;
         this.classLoader = classLoader;
         this.webApplicationDescriptor = webApplicationDescriptor;
         this.listener = listener;
         this.mockedFieldsRepository = mockedFieldsRepository;
-    }
-    
-    private LoadClassAction(List<String> classes, ClassLoader classLoader, WebApplicationDescriptor webApplicationDescriptor, ProgressListener listener, MockedFieldsRepository mockedFieldsRepository, int from, int to) {
-        this(classes, classLoader, webApplicationDescriptor, listener, mockedFieldsRepository);
         this.from = from;
         this.to = to;
     }


### PR DESCRIPTION
Hi, I’m a PhD student doing research on ForkJoin usage, and I found that your code can be improved for better performance and energy efficiency.

Using this modification, there is no need to create new List<String> classes instances during the ForkJoin recursive operation. It will save you some memory, time, and energy consumption.